### PR TITLE
suggest built-in python server over npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Run the following command to generate a _project structure dump_ in JSON:
 $ cargo run -- -p <your-cargo-project>
 ```
 
-Run a static server on port 80 (make sure `http-server` is installed: `npm install http-server`):
+Run a static server on port 8000:
 
 ```
-$ sudo http-server . -p 80 --cors
+$ python -m http.server 8000
 ```
 
-Finally, open http://localhost/index.html and see the result!
+Finally, open `http://localhost:8000/index.html` and see the result!
 
 ## Gallery
 


### PR DESCRIPTION
Nice tool!

Just a suggestion here, using python's built-in http server instead of the http-server npm package.  It doesn't require dipping into an adjacent ecosystem (npm).  I also changed the port to the range where regular user permissions are sufficient.  sudo'ing npm packages is risky.